### PR TITLE
Correct  typo in the repository

### DIFF
--- a/charts/mongo-db/Chart.yaml
+++ b/charts/mongo-db/Chart.yaml
@@ -9,4 +9,4 @@ appVersion: "4.4.12" # MongoDB version 4.4.12
 dependencies:
 - name: mongodb
   version: 12.1.31
-  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnam
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami


### PR DESCRIPTION
 I think there may be a typo in the K3s repo [here](https://github.com/wistefan/fiware-on-k3s/blob/main/charts/mongo-db/Chart.yaml#L12) - when I run the maven build, I get a 404 not found error. Comparing  this to the [GitOps repo](https://github.com/FIWARE-Ops/fiware-gitops/blob/master/aws/fiware/mongodb/Chart.yaml#L12) and the legacy charts [issue] (https://github.com/bitnami/charts/issues/10539) it looks like the repository name is missing the final `i`